### PR TITLE
Implement `sink_metrics` for managing batching statistic.

### DIFF
--- a/apps/rtp/src/aggregator/sink.erl
+++ b/apps/rtp/src/aggregator/sink.erl
@@ -120,9 +120,15 @@ create_timer() ->
 	erlang:send_after(?INTERVAL, self(), trigger).
 
 update_timer(State = #sink_state{timer = TimerRef}) ->
-	_ = erlang:cancel_timer(TimerRef),
+	TimerResult = erlang:cancel_timer(TimerRef),
+	publish_timer_metrics(TimerResult),
 	NewTimerRef = create_timer(),
 	NewState = State#sink_state{timer = NewTimerRef},
 	NewState.
+
+publish_timer_metrics(false) ->
+	gen_server:cast(message_broker, {publish, sink_metrics, ?INTERVAL});
+publish_timer_metrics(TimerResult) ->
+	gen_server:cast(message_broker, {publish, sink_metrics, ?INTERVAL - TimerResult}).
 
 

--- a/apps/rtp/src/percentile/sink_metrics.erl
+++ b/apps/rtp/src/percentile/sink_metrics.erl
@@ -1,0 +1,84 @@
+%%%-------------------------------------------------------------------
+%%% @author Volcov Oleg
+%%% @copyright (C) 2022, FAF-191
+%%% @doc
+%%% @end
+%%%-------------------------------------------------------------------
+-module(sink_metrics).
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+	terminate/2]).
+-export([get_specs/0]).
+
+-define(INTERVAL, 3000).
+
+-record(percentile_state, {list}).
+
+%%%===================================================================
+%%% Spawning and gen_server implementation
+%%%===================================================================
+
+start_link() ->
+	gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+	gen_server:cast(message_broker, {subscribe, sink_metrics, self()}),
+	erlang:send_after(?INTERVAL, self(), trigger),
+	NewState = #percentile_state{list = []},
+	{ok, NewState}.
+
+handle_call(_Request, _From, State = #percentile_state{}) ->
+	{reply, ok, State}.
+
+handle_cast({sink_metrics, Data}, State = #percentile_state{list = List}) ->
+    NewState = State#percentile_state{list = [Data|List]},
+    {noreply, NewState};
+handle_cast(_Request, State = #percentile_state{}) ->
+	{noreply, State}.
+
+handle_info(trigger, State = #percentile_state{list = List}) ->
+	SortedList = lists:sort(List),
+	ListSize = length(SortedList),
+
+	P75th = calculate_percentile(ListSize, SortedList, 75),
+	P90th = calculate_percentile(ListSize, SortedList, 90),
+	P95th = calculate_percentile(ListSize, SortedList, 95),
+
+	io:format("~n[~p] percentile's calculation of execution time for last ~p millis[in millis]:~n", [self(), ?INTERVAL]),
+	io:format("  `75th`=~p,~n  `90th`=~p,~n  `95th`=~p.~n~n", [P75th, P90th, P95th]),
+
+	erlang:send_after(?INTERVAL, self(), trigger),
+	NewState = State#percentile_state{list = []},
+	{noreply, NewState};
+handle_info(_Info, State = #percentile_state{}) ->
+	{noreply, State}.
+
+terminate(_Reason, _State) ->
+	gen_server:cast(message_broker, {unsubscribe, sink_metrics, self()}),
+	ok.
+
+%%%===================================================================
+%%% External functions
+%%%===================================================================
+
+get_specs() ->
+	#{
+		id => sink_metrics,
+		start => {sink_metrics, start_link, []},
+		restart => permanent,
+		type => worker,
+		modules => [sink_metrics]
+	}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+calculate_percentile(ListSize, SortedList, Percentile) ->
+	IndexFloat = math:ceil(Percentile / 100.0 * ListSize),
+	Index = trunc(IndexFloat),
+
+	lists:nth(Index - 1, SortedList).

--- a/apps/rtp/src/rtp_sup.erl
+++ b/apps/rtp/src/rtp_sup.erl
@@ -35,6 +35,7 @@ init([]) ->
     Aggregator = aggregator:get_specs(),
     Sink = sink:get_specs(),
     MessageBroker = message_broker:get_specs(),
+    SinkMetrics = sink_metrics:get_specs(),
 
     RetweetGroupSup = worker_group_utils:get_specs("retweet", retweet_processing:work_handler()),
     HashTagGroupSup = worker_group_utils:get_specs("hash_tag", hashtag_processing:work_handler()),
@@ -48,6 +49,7 @@ init([]) ->
         SSEHandlerSup,
         Aggregator,
         Sink,
+        SinkMetrics,
 
         RetweetGroupSup,
         HashTagGroupSup,


### PR DESCRIPTION
## What?
 
* Create `sink_metrics` to calculate `percentiles` for `sink` execution time.
* Update `sink` to send execution time by `message_broker`.
* Add `sink_metrics` in main supervisor.